### PR TITLE
Add GitHub Actions workflow for release notifications to Slack

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,0 +1,14 @@
+name: Release Notifications
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify-slack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack Notification
+        uses: udhaykumarbala/slack-release-notifier@v1.0.1
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }} 


### PR DESCRIPTION
Added a github action on release to notify 
Mandatory to add secrets to make it work
<img width="3440" height="2346" alt="CleanShot 2025-07-28 at 11 13 05@2x" src="https://github.com/user-attachments/assets/723621bb-adf3-4b8a-86ec-91a64a3f24f0" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0gchain-NG/9)
<!-- Reviewable:end -->
